### PR TITLE
Adds tracking of bot option in Matomo configuration variable, #PG-3361

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -122,6 +122,13 @@ ___TEMPLATE_PARAMETERS___
   },
   {
     "type": "CHECKBOX",
+    "name": "trackBots",
+    "checkboxText": "Track Bots",
+    "simpleValueType": true,
+    "help": "By default, Matomo doesn\u0027t track visits by bots in order to show accurate visitor metrics. Enable this feature to add tracking for bot visits."
+  },
+  {
+    "type": "CHECKBOX",
     "name": "disableCookies",
     "checkboxText": "Disable cookies",
     "simpleValueType": true,
@@ -317,7 +324,7 @@ if (data.matomoUrl && data.idSite) {
   
   var domains = getDomains();
   if (domains.length) {
-    _paq(["setDomains",domains]);
+    _paq(["setDomains", domains]);
   }
   
   configWithValues = {'userId':'setUserId'};
@@ -333,6 +340,10 @@ if (data.matomoUrl && data.idSite) {
   
   enableConfigValues = {'enableDoNotTrack':'setDoNotTrack', 'enableJSErrorTracking':'enableJSErrorTracking', 'enableHeartBeatTimer':'enableHeartBeatTimer','trackAllContentImpressions':'trackAllContentImpressions', 'trackVisibleContentImpressions':'trackVisibleContentImpressions'};
   paqEnable(_paq, enableConfigValues);
+  
+  if (data.trackBots) {
+     _paq(['appendToTrackingUrl', 'bots=1']);
+  }
   
   
   disableConfigValues = {'doNotUseSendBeacon':'alwaysUseSendBeacon'};


### PR DESCRIPTION
### Description:

Adds tracking of bot option in Matomo configuration variable
Fixes: #PG-3361

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
